### PR TITLE
Added missing dependency check for SimpleSAMLphp

### DIFF
--- a/app/View/Pages/home.ctp
+++ b/app/View/Pages/home.ctp
@@ -193,4 +193,19 @@ if (isset($filePresent)):
 		endif;
 	?>
 </p>
-<?php endif;
+<?php endif; ?>
+<?php
+if (file_exists('/usr/share/simplesamlphp/lib/_autoload.php')):
+	echo '<div class="alert alert-success">';
+		echo __d('cake_dev', 'SimpleSAMLphp is present');
+	echo '</div>';
+else:
+	echo '<div class="alert alert-error">';
+		echo __d(
+			'cake_dev',
+			'%s is not installed. It is needed to log in with %s.',
+			$this->Html->link('SimpleSAMLphp', 'http://simplesamlphp.org/'),
+			$this->Html->link('SURFconext', 'http://www.surfnet.nl/nl/Thema/coin')
+		);
+	echo '</div>';
+endif;


### PR DESCRIPTION
You won't be able to log out when SimpleSAMLphp is not installed.
